### PR TITLE
Fix: Second installation is failing

### DIFF
--- a/app/post-update.sh
+++ b/app/post-update.sh
@@ -8,11 +8,12 @@ loadEnvFile
 
 echo "Updating Shopware install, please wait..."
 
+createSymLinks
+
 swCommand sw:migrations:migrate --mode=update
 swCommand sw:cache:clear
 swCommand sw:theme:cache:generate
 swCommand sw:plugin:update --batch=active
-createSymLinks
 
 echo -e "\n\nDone!\n"
 


### PR DESCRIPTION
## to reconstruct
- install shopware using project template, see https://developers.shopware.com/developers-guide/shopware-composer/
- push installation to your own git repository
- switch to different server or directory
- clone your own repo again
- run composer install

installation failes throwing following message:

```
  [Exception]                                       
  Theme directory Responsive contains no Theme.php  
```

moving "createSymlinks" before doing these php stuff is solving it :-)