### PR TITLE
fix broken coloring control sequence

### DIFF
--- a/app/functions.sh
+++ b/app/functions.sh
@@ -58,9 +58,9 @@ function swCommand(){
 }
 
 function banner(){
-    echo -e -n $'\e[34m'
-    echo -e | cat ${__DIR__}/banner.txt
-    echo -e $'\e[0m'
+    echo -e -n '\e[34m'
+    cat ${__DIR__}/banner.txt
+    echo -e '\e[0m'
 }
 
 function envFileDoesNotExists(){

--- a/app/functions.sh
+++ b/app/functions.sh
@@ -58,7 +58,7 @@ function swCommand(){
 }
 
 function banner(){
-    echo -e -n $'\e[34m\e[1'
+    echo -e -n $'\e[34m'
     echo -e | cat ${__DIR__}/banner.txt
     echo -e $'\e[0m'
 }

--- a/app/functions.sh
+++ b/app/functions.sh
@@ -151,7 +151,7 @@ function createEnvFile(){
 
 function loadEnvFile(){
     if [ -f $__DIR__/../.env ]; then
-        echo "${blue}${bold}Loading configuration settings from .env file${reset}"
+        echo "${green}Loading configuration settings from .env file${reset}"
         source $__DIR__/../.env
         return
     fi

--- a/app/functions.sh
+++ b/app/functions.sh
@@ -22,6 +22,15 @@ function get_realpath(){
 declare -r __FILE__=$(get_realpath ${BASH_SOURCE[0]})
 declare -r __DIR__=$(dirname $__FILE__)
 
+# Coloring/Styling helpers
+esc=$(printf '\033')
+reset="${esc}[0m"
+blue="${esc}[34m"
+green="${esc}[32m"
+red="${esc}[31m"
+bold="${esc}[1m"
+warn="${esc}[41m${esc}[97m"
+
 function printError(){
     >&2 echo -e "$@"
 }
@@ -58,9 +67,9 @@ function swCommand(){
 }
 
 function banner(){
-    echo -e -n '\e[34m'
+    echo -n "${blue}"
     cat ${__DIR__}/banner.txt
-    echo -e '\e[0m'
+    echo "${reset}"
 }
 
 function envFileDoesNotExists(){
@@ -142,7 +151,7 @@ function createEnvFile(){
 
 function loadEnvFile(){
     if [ -f $__DIR__/../.env ]; then
-        echo -e "\033[1;34mLoading configuration settings from .env file\033[0m"
+        echo "${blue}${bold}Loading configuration settings from .env file${reset}"
         source $__DIR__/../.env
         return
     fi

--- a/app/install.sh
+++ b/app/install.sh
@@ -11,10 +11,7 @@ fi
 
 loadEnvFile
 
-BC=$'\e[41m\e[97m'
-EC=$'\e[0m'
-
-DROP_DATABASE=$(promptYesOrNo "Start installation? This will drop the database ${BC}$DATABASE_URL${EC}! (y/N) " 'n')
+DROP_DATABASE=$(promptYesOrNo "Start installation? This will drop the database ${warn}$DATABASE_URL${reset}! (y/N) " 'n')
 if [ $DROP_DATABASE = n ]; then
     echo -e "\nNot touching the database, have fun!\n"
     exit 0;


### PR DESCRIPTION
as noted in the [comment](https://github.com/shopware/composer-project/commit/6d4404d5542762038a1dfc54237ee6fa0f3bbc9f#r27541562), xterm emulators will tolerate the broken sequence, not gnome-terminal though. Please fix for unhindered ascii banner glory

![glitch](https://user-images.githubusercontent.com/8349171/38824713-6b23c29c-41aa-11e8-8775-35d2053c814b.png)
