### PR TITLE
Adds plugin refresh command to post-update script

### DIFF
--- a/app/post-update.sh
+++ b/app/post-update.sh
@@ -13,6 +13,7 @@ createSymLinks
 swCommand sw:migrations:migrate --mode=update
 swCommand sw:cache:clear
 swCommand sw:theme:cache:generate
+swCommand sw:plugin:refresh
 swCommand sw:plugin:update --batch=active
 
 echo -e "\n\nDone!\n"


### PR DESCRIPTION
Without this command it is possible that plugins are not updated, because shopware is not aware of the new version.