### PR TITLE
add missing m to shell escape sequence

### DIFF
--- a/app/functions.sh
+++ b/app/functions.sh
@@ -58,7 +58,7 @@ function swCommand(){
 }
 
 function banner(){
-    echo -e -n $'\e[34m\e[1'
+    echo -e -n $'\e[34m\e[1m'
     echo -e | cat ${__DIR__}/banner.txt
     echo -e $'\e[0m'
 }


### PR DESCRIPTION
This PR fixes a problem with wrong usage of terminfo capabilities (i.e. a shell format escape sequence).

See for example:
https://wiki.archlinux.org/index.php/Bash/Prompt_customization#Common_capabilities