### PR TITLE
[RFC] enable autoloader to load other environments than .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 engine/*
 .env
+.env.*
+!.env.example
 
 # PhpStorm-Project
 /.idea/

--- a/.htaccess
+++ b/.htaccess
@@ -47,7 +47,7 @@ DirectoryIndex index.php
 DirectoryIndex shopware.php
 
 # Disables download of configuration
-<Files ~ "\.(tpl|yml|ini)$">
+<Files ~ "\.(tpl|yml|ini|env|env.*)$">
     # Deny all requests from Apache 2.4+.
     <IfModule mod_authz_core.c>
           Require all denied

--- a/app/autoload.php
+++ b/app/autoload.php
@@ -11,9 +11,15 @@ $loader = require __DIR__.'/../vendor/autoload.php';
 
 AnnotationRegistry::registerLoader([$loader, 'loadClass']);
 
+$shopwareEnv = preg_replace('/[^a-zA-Z0-9-_.]/', '', getenv('SHOPWARE_ENV'));
+if (false === empty($shopwareEnv) && file_exists(__DIR__ . '/../.env.' . $shopwareEnv)) {
+    $dotenv = new Dotenv(__DIR__ . '/../', '.env.' . $shopwareEnv);
+    $dotenv->load();
+}
+
 if (file_exists(__DIR__ . '/../.env')) {
     $dotenv = new Dotenv(__DIR__ . '/../');
-    $dotenv->load();
+    $dotenv->overload();
 }
 
 return $loader;


### PR DESCRIPTION
I very much like the ability to define the environment variable `SHOPWARE_ENV` and thus the ability to use different configs.
But: I also like the idea to define configuration in `.env`. This is especially useful if you want to use the configuration additionally in shell scripts (as we do in some development environment/automation).

This PR suggest a method to transfer the the idea of `SHOPWARE_ENV` to `.env` files.

It works as follows:

If `SHOPWARE_ENV` is not set, only `.env` file is loaded.
If `SHOPWARE_ENV` is set (for example to `dev`) and a file called `.env.dev` exists, it will be loaded first. After that the file `.env` is loaded overriding existing environment variables.

This way you can define configuration for different environments (staging, production, dev, test, ...) and keep them in source control and switch between them by settings `SHOPWARE_ENV`.

This is a request for comments. I'd appreciate to read your opinions.
(This includes the naming of the file. Feel free to provide alternatives, for example if you like `dev.env` or yet another more.)