### PR TITLE
Adds phpunit tests directory via symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ engine/*
 /composer.phar
 /vendor/*
 
+# PHPUnit
+/tests
+
 # Themes
 /themes/Backend/ExtJs
 /themes/Frontend/Bare

--- a/app/functions.sh
+++ b/app/functions.sh
@@ -182,6 +182,9 @@ function createSymLinks(){
     ln -s ../../vendor/shopware/shopware/engine/Library/CodeMirror engine/Library/CodeMirror
     ln -s ../../vendor/shopware/shopware/engine/Library/ExtJs engine/Library/ExtJs
     ln -s ../../vendor/shopware/shopware/engine/Library/TinyMce engine/Library/TinyMce
+    
+    rm -rf tests
+    ln -s vendor/shopware/shopware/tests tests
 
     rm -rf themes/Frontend/{Bare,Responsive}
     rm -rf themes/Backend/ExtJs


### PR DESCRIPTION
This PR adds a new symlink to the document root for phpunit tests. This aims to add support for the [Plugin testing](https://developers.shopware.com/developers-guide/plugin-testing/) guide from the documentation. In the current state this does not work out of the box because the path mentioned in [this section](https://developers.shopware.com/developers-guide/plugin-testing/#basics) would need to be different. Instead of `/../../../../../Tests/Functional/bootstrap.php` for the composer installation you would have to write `/../../../../../vendor/shopware/shopware/Tests/Functional/bootstrap.php`. Therefore it would be bound to the environment and should not be part of the versioned code.

To eliminate this inconsistency this PR adds a symlink to make shopware composer installations compatible with the testing approach described in the documentation.