### PR TITLE
Require PHP 7.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "classmap": [ "app/AppKernel.php" ]
     },
     "require": {
-        "php": "^5.6.4||^7.0",
+        "php": "^7.0",
         "composer/installers": "^1.0",
         "shopware/shopware": "^5.4",
         "vlucas/phpdotenv": "~2.0"
@@ -30,10 +30,7 @@
     ],
     "config": {
         "optimize-autoloader": true,
-        "process-timeout": 0,
-        "platform": {
-            "php": "5.6.4"
-        }
+        "process-timeout": 0
     },
     "scripts": {
         "post-root-package-install": [


### PR DESCRIPTION
Hello.

Since PHP 5.6 is last PHP 5.x version and it's EOL is at the end of this year, it should not be supported anymore, especially on new projects.

This pull request does 2 things:

* removes platform fake in Composer since we should rely on really used PHP version
* removes PHP 5.6 from requirements (although it's been alternative to 7.0)

Changes are related to https://github.com/shopware/shopware/pull/1705

