### PR TITLE
Sanitize loaded Shopware version from Composer

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -8,6 +8,18 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 class AppKernel extends Kernel
 {
     /**
+     * @param string $environment
+     * @param bool   $debug
+     *
+     * @throws \Exception
+     */
+    public function __construct($environment, $debug)
+    {
+        $this->loadRelease();
+        parent::__construct($environment, $debug);
+    }
+
+    /**
      * @return string
      */
     protected function getConfigPath()
@@ -46,37 +58,38 @@ class AppKernel extends Kernel
         return parent::prepareContainer($container);
     }
 
-    /**
-     * @param string $environment
-     * @param bool   $debug
-     *
-     * @throws \Exception
-     */
-    public function __construct($environment, $debug)
+    private function loadRelease()
     {
-        /**
-         * Setting the environment variables, either directly, by the webserver or using the .env-file
-         * allows you to define a custom Shopware version IF NECESSARY.
-         *
-         * It should match the version being installed by composer. This way plugins still are able to check
-         * for the Shopware version.
-         *
-         * YOU SHOULDN'T NORMALLY HAVE TO DO THIS! (See below)
-         */
+        $this->loadReleaseFromEnv();
+        $this->loadReleaseFromComposer();
+    }
+
+    /**
+     * Setting the environment variables, either directly, by the webserver or using the .env-file
+     * allows you to define a custom Shopware version IF NECESSARY.
+     *
+     * It should match the version being installed by composer. This way plugins still are able to check
+     * for the Shopware version.
+     *
+     * YOU SHOULDN'T NORMALLY HAVE TO DO THIS! (See below)
+     */
+    private function loadReleaseFromEnv()
+    {
         $this->release['version'] = getenv('SHOPWARE_VERSION') === false ? self::VERSION : getenv('SHOPWARE_VERSION');
         $this->release['revision'] = getenv('SHOPWARE_REVISION') === false ? self::REVISION : getenv('SHOPWARE_REVISION');
         $this->release['version_text'] = getenv('SHOPWARE_VERSION_TEXT') === false ? self::VERSION_TEXT : getenv('SHOPWARE_VERSION_TEXT');
+    }
 
-        /**
-         * We try to determine the installed version of Shopware automatically.
-         */
+    /**
+     * We try to determine the installed version of Shopware automatically.
+     */
+    private function loadReleaseFromComposer()
+    {
         try {
             list($version, $sha) = explode('@', \PackageVersions\Versions::getVersion('shopware/shopware'));
             $this->release['version'] = preg_replace('/[^0-9.]/', '', $version);
             $this->release['revision'] = $sha;
         } catch (\OutOfBoundsException $ex) {
         }
-
-        parent::__construct($environment, $debug);
     }
 }

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -72,7 +72,7 @@ class AppKernel extends Kernel
          */
         try {
             list($version, $sha) = explode('@', \PackageVersions\Versions::getVersion('shopware/shopware'));
-            $this->release['version'] = $version;
+            $this->release['version'] = preg_replace('/[^0-9.]/', '', $version);
             $this->release['revision'] = $sha;
         } catch (\OutOfBoundsException $ex) {
         }


### PR DESCRIPTION
Version loaded from Composer can include some characters which then result to problems when installing plugins (`[Exception]  Plugin requires at least Shopware version 5.2.0`).

This change sanitizes version constraint to include only numbers and dots.

Example: `v5.4.6` is sanitized to `5.4.6`.