### PR TITLE
WIP: Fix \Shopware::DocPath() root dir

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -58,6 +58,15 @@ class AppKernel extends Kernel
         return parent::prepareContainer($container);
     }
 
+    /**
+     * Creates a new instance of the Shopware application
+     */
+    protected function initializeShopware()
+    {
+        $this->shopware = new \AppShopware($this->container);
+        $this->container->setApplication($this->shopware);
+    }
+
     private function loadRelease()
     {
         $this->loadReleaseFromEnv();

--- a/app/AppShopware.php
+++ b/app/AppShopware.php
@@ -1,0 +1,18 @@
+<?php
+
+use Shopware\Components\DependencyInjection\Container;
+
+/**
+ * This overrides the original Shopware class and fixes path specification.
+ * Those paths could be used by other code via \Shopware::DocPath()
+ */
+class AppShopware extends \Shopware
+{
+
+    public function __construct(Container $container)
+    {
+        parent::__construct($container);
+        $this->docPath = dirname(__DIR__) . DIRECTORY_SEPARATOR;
+    }
+
+}

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,10 @@
         }
     ],
     "autoload": {
-        "classmap": [ "app/AppKernel.php" ]
+        "classmap": [
+            "app/AppKernel.php",
+            "app/AppShopware.php"
+        ]
     },
     "require": {
         "php": "^7.0",


### PR DESCRIPTION
Shopware provides a method to retrieve project root directory via \Shopware::DocPath()
When using shopware/composer-project the original one is not correct since it's vendor/shopware/shopware.

Some mainly older Plugins (e.g. SwagImportExport) and possible custom code may rely on it and may be malfunction.

This fixes the path to be as real project root.
Solution should be fixed in the /Shopware class itself by removing root directory determination and rely on something else.