### PR TITLE
Readme: Add Configuration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ To use the installer, simply run:
 $ ./app/install.sh
 ```
 
+## Configuration
+
+Configuration like database credentials should be set via environment variables.
+You can use `.env` file when cannot use them.
+
+You can configure also some generic project services in `app/services.xml`.
+For instance, error log is configured to use `stderr` output instead of default log file
+located at `var/log` directory.
+
 ## Updating Shopware
 
 Update the version number of `shopware/shopware` in `composer.json`. Then run `composer update shopware/shopware`


### PR DESCRIPTION
In shopware/composer-project there is changed behavior of Shopware error logger. It uses `stderr` instead of file at `var/log`.

This can lead to potential confusion after upgrading Shopware 5.3 application to Shopware 5.4 shopware/composer-project.

This adds note in README file including the mention of `app/services.xml` for generic project services definition.