### PR TITLE
Handle composer version numbers with leading v

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -94,6 +94,11 @@ class AppKernel extends Kernel
             list($version, $sha) = explode('@', \PackageVersions\Versions::getVersion('shopware/shopware'));
 
             /*
+             * Trim leading v from versions like "v5.4.6"
+             */
+            $version = preg_replace('/^[v]/','',$version);
+
+            /*
              * Make sure the version matches some expected patterns like "5.4.0" or "5.0.0-RC1"
              */
             if (!preg_match('/^([\d]+\.[\d]+\.[\d]+(\-[a-zA-Z\d]{0,4})?)$/', $version)) {


### PR DESCRIPTION
I installed Shopware with the composer project and issues installing plugins, because the version number was "unknown".
In the File "vendor/ocramius/package-versions/src/PackageVersions/Versions.php" the shopware version looks like this:
```php
final class Versions
{
    const VERSIONS = array (
  [...]
  'setasign/fpdi' => '1.6.2@a6ad58897a6d97cc2d2cd2adaeda343b25a368ea',
  'shopware/shopware' => 'v5.4.6@bb286779ee8e8867e9942aedf41be24298f87ac2',
  'symfony/class-loader' => 'v2.8.41@f87f46e5e1bf31382a65966795fa2d4dd7e2b300',
  [...]
);
```

This doesn't match in the existing version check because of the leading `v`. So I think we have to add a small step to remove the leading `v`.