### PR TITLE
Load configuration files from project root

### DIFF
--- a/app/config/config.php
+++ b/app/config/config.php
@@ -17,6 +17,14 @@ if (!$db) {
 
 $projectDir = dirname(dirname(__DIR__)) . DIRECTORY_SEPARATOR;
 
+if (file_exists($projectDir . 'config_' . $this->Environment() . '.php')) {
+    $customConfig = $this->loadConfig($projectDir . 'config_' . $this->Environment() . '.php');
+} elseif (file_exists($projectDir . 'config.php')) {
+    $customConfig = $this->loadConfig($projectDir . 'config.php');
+} else {
+    $customConfig = [];
+}
+
 return array_replace_recursive($this->loadConfig($this->AppPath() . 'Configs/Default.php'), [
 
     'db' => [

--- a/app/config/config.php
+++ b/app/config/config.php
@@ -74,4 +74,4 @@ return array_replace_recursive($this->loadConfig($this->AppPath() . 'Configs/Def
         'webDir' => $projectDir . 'web',
         'cacheDir' => $projectDir . 'web/cache',
     ],
-]);
+], $customConfig);


### PR DESCRIPTION
Hi,

currently the composer shopware version can not load config.php and config_*.php from the project root. This PR adds this functionality.

If it can be achieved in an other way please let me know. Thanks.