### PR TITLE
use correct val for IMPORT_DEMODATA in .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,4 +23,4 @@ ADMIN_USERNAME=demo
 ADMIN_PASSWORD=demo
 
 # Import demodata during initial shop installation
-IMPORT_DEMODATA=true
+IMPORT_DEMODATA=y


### PR DESCRIPTION
I had to search for a moment to find out why I wasn't offered the import for the demo data.
./app/install.sh checks for "IMPOT_DEMODATA=y" instead of "true".