### PR TITLE
[FEATURE] allow DROP_DATABASE to be set via env

### DIFF
--- a/app/bin/install.sh
+++ b/app/bin/install.sh
@@ -11,7 +11,7 @@ fi
 
 loadEnvFile
 
-DROP_DATABASE=$(promptYesOrNo "Start installation? This will drop the database ${warn}$DATABASE_URL${reset}! (y/N) " 'n')
+DROP_DATABASE=${DROP_DATABASE:-$(promptYesOrNo "Start installation? This will drop the database ${warn}$DATABASE_URL${reset}! (y/N) " 'n')}
 if [ $DROP_DATABASE = n ]; then
     echo -e "\nNot touching the database, have fun!\n"
     exit 0;


### PR DESCRIPTION
At the moment the install script can not be run unattended, because there is no way to set the `DROP_DATABASE` via the environment. All the other variables are fine, so I guess we should be able to set `DROP_DATABASE=y` also. 