### PR TITLE
fix error when no password provided in DATABASE_URL

### DIFF
--- a/app/config/config.php
+++ b/app/config/config.php
@@ -5,6 +5,7 @@ $db = false;
 if (getenv('DATABASE_URL') && $db = parse_url(getenv('DATABASE_URL'))) {
     $db = array_map('rawurldecode', $db);
     $db['path'] = substr($db['path'], 1);
+    if (!isset($db['pass'])) $db['pass'] = '';
 } else {
     // Fallback if e.g. the password contains URL invalid parameters
     $db['user'] = getenv('DB_USERNAME');


### PR DESCRIPTION
Fix `Notice: Undefined index: pass in .../app/config/config.php on line 24` error that appears when executing `install.sh` and an empty password is provided in the DATABASE_URL env variable (in local dev environments for example).