### PR TITLE
Made Shopware()->DocPath() compatible with composer installations

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -19,6 +19,12 @@ class AppKernel extends Kernel
         parent::__construct($environment, $debug);
     }
 
+    protected function initializeShopware()
+    {
+        $this->shopware = new Application($this->container);
+        $this->container->setApplication($this->shopware);
+    }
+
     /**
      * @return string
      */

--- a/app/Application.php
+++ b/app/Application.php
@@ -1,0 +1,16 @@
+<?php
+
+use Shopware\Components\DependencyInjection\Container;
+
+class Application extends Shopware
+{
+    /**
+     * @param Container $container
+     */
+    public function __construct(Container $container)
+    {
+        parent::__construct($container);
+
+        $this->docPath = dirname(__DIR__) . DIRECTORY_SEPARATOR;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "autoload": {
         "classmap": [
+            "app/Application.php",
             "app/AppKernel.php",
             "app/ShopwareVersion.php"
         ]


### PR DESCRIPTION
By default `Shopware()->DocPath()` would return `vendor/shopware/shopware/` which is not the project root. This decorates the application class and sets the actual project root as the docPath.