### PR TITLE
Adds port to database fallback config loading

### DIFF
--- a/app/config/config.php
+++ b/app/config/config.php
@@ -24,6 +24,7 @@ return array_replace_recursive($this->loadConfig($this->AppPath() . 'Configs/Def
         'password' => $db['pass'],
         'dbname'   => $db['path'],
         'host'     => $db['host'],
+        'port'     => $db['port'],
     ],
 
     'template' => [


### PR DESCRIPTION
The [database-bridge](https://github.com/shopware/shopware/blob/5.5/engine/Shopware/Components/DependencyInjection/Bridge/Db.php#L147) supports a port parameter. The [environment loader](https://github.com/shopware/composer-project/blob/master/app/config/config.php#L14) supports a port parameter. This parameter *should* be passed to the bridge.