### PR TITLE
Add TRUSTEDPROXIES .env variable...

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,6 @@ ADMIN_PASSWORD=demo
 # Import demodata during initial shop installation
 IMPORT_DEMODATA=y
 INSTALL_IMAGES=y
+
+# Trustedproxies setting for e.g. using separate https proxy; use comma-separated IPs without spaces
+TRUSTEDPROXIES=""

--- a/app/config/config.php
+++ b/app/config/config.php
@@ -19,6 +19,7 @@ $projectDir = dirname(dirname(__DIR__)) . DIRECTORY_SEPARATOR;
 
 return array_replace_recursive($this->loadConfig($this->AppPath() . 'Configs/Default.php'), [
 
+    'trustedproxies' => explode(',', getenv('TRUSTEDPROXIES')),
     'db' => [
         'username' => $db['user'],
         'password' => $db['pass'],


### PR DESCRIPTION
... and integrate into app/config/config.php

All our dev/int/test systems are accessed via a central https proxy with wildcard certificate. So I would like to be able to add this setting from the start for unattended installs.