### PR TITLE
Just ignore user specific .idea-files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,28 @@
 engine/*
 .env
 
-# PhpStorm-Project
-/.idea/
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+# Taken from https://github.com/github/gitignore/blob/8e9a976642709c516fbf5dae2eba14dfd78ed0d0/Global/JetBrains.gitignore#L2-L21
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
 
 # Composer
 /composer.phar


### PR DESCRIPTION
As the composer project resembles a whole application and is forked a lot these application specific settings for PhpStorm (which is guessed the most used IDE for this project) should be as pointed out by @shyim 

> den cache schließt man aus
> eigentlich sollte man sowas auch in das shopware projekt rein committen (.idea ordner mit der datei)
> Solche Standard Exclude wie cache etc kann man ja ruhig committen

taken from [chat](https://gitter.im/shopware/offtopic?at=5ca5ad2cc55bd14d35873a38)

As this .gitignore file discloses the commiting of these files we just have to follow the JetBrains ignore rules instead and this project benefits from it a lot.