### PR TITLE
Deactivate media live migration

### DIFF
--- a/app/config/config.php
+++ b/app/config/config.php
@@ -45,7 +45,7 @@ return array_replace_recursive($this->loadConfig($this->AppPath() . 'Configs/Def
     ],
 
     'cdn' => [
-        'liveMigration' => true,
+        'liveMigration' => false,
         'adapters' => [
             'local' => [
                 'path' => $projectDir,


### PR DESCRIPTION
In the main shopware repository, the default value for the media
liveMigration setting is false. This should be the case for this
repository too, because missing images causes a very slow page load
because of session_start.