### PR TITLE
Fix installer path for legacy plugin system

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
     },
     "extra": {
         "installer-paths": {
-            "Plugins/Local/Backend/{$name}/": ["type:shopware-backend-plugin"],
-            "Plugins/Local/Core/{$name}/": ["type:shopware-core-plugin"],
-            "Plugins/Local/Frontend/{$name}/": ["type:shopware-frontend-plugin"]
+            "Plugins/Community/Backend/": ["type:shopware-backend-plugin"],
+            "Plugins/Community/Core/": ["type:shopware-core-plugin"],
+            "Plugins/Community/Frontend/": ["type:shopware-frontend-plugin"]
         }
     },
     "include-path": [


### PR DESCRIPTION
Required Plugins should be installed in Community. Local should be project plugins :)
Also plugin folder was duplicate like Plugins/Local/Core/ViisonPickwareErp/ViisonPickwareErp/Bootstrap.php