### PR TITLE
Allow linking to fail on initial import

### DIFF
--- a/app/bin/post-install.sh
+++ b/app/bin/post-install.sh
@@ -2,7 +2,7 @@
 
 source $(dirname "$0")/functions.sh
 
-createSymLinks
+createSymLinks || true
 
 set -eu
 


### PR DESCRIPTION
The script `post-install.sh` also runs on the initial creation of a new project, before the dependencies have already been installed. In that case linking of the folders and files fails.

This case is now being ignored and subsequent calls can create the symlinks just as always.