### PR TITLE
Change install event

### DIFF
--- a/app/bin/post-install.sh
+++ b/app/bin/post-install.sh
@@ -2,7 +2,7 @@
 
 source $(dirname "$0")/functions.sh
 
-createSymLinks
+createSymLinks || true
 
 set -eu
 

--- a/app/bin/post-update.sh
+++ b/app/bin/post-update.sh
@@ -3,20 +3,27 @@
 source $(dirname "$0")/functions.sh
 
 banner
+if envFileDoesNotExists
+    then
+        echo -e "\nPlease run app/bin/install.sh manually to finish your installation\n"
+    else
+        loadEnvFile
 
-loadEnvFile
+        echo "Updating Shopware install, please wait..."
 
-echo "Updating Shopware install, please wait..."
+        createSymLinks
 
-createSymLinks
+        swCommand sw:migrations:migrate --mode=update
+        swCommand sw:theme:synchronize
+        swCommand sw:cache:clear
+        swCommand sw:theme:cache:generate
+        swCommand sw:plugin:refresh
+        swCommand sw:plugin:update --batch=active
+        swCommand sw:snippets:to:db
 
-swCommand sw:migrations:migrate --mode=update
-swCommand sw:theme:synchronize
-swCommand sw:cache:clear
-swCommand sw:theme:cache:generate
-swCommand sw:plugin:refresh
-swCommand sw:plugin:update --batch=active
-swCommand sw:snippets:to:db
+        echo -e "\n\nDone!\n"
 
-echo -e "\n\nDone!\n"
+        exit 0
+    fi
+
 

--- a/composer.json
+++ b/composer.json
@@ -39,9 +39,6 @@
         "sort-packages": true
     },
     "scripts": {
-        "post-root-package-install": [
-           "./app/bin/post-install.sh"
-        ],
         "post-install-cmd": [
            "./app/bin/post-install.sh"
         ],

--- a/shopware.php
+++ b/shopware.php
@@ -4,9 +4,7 @@ use Shopware\Components\HttpCache\AppCache;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\TerminableInterface;
 
-/**
- * @var Composer\Autoload\ClassLoader
- */
+/** @var Composer\Autoload\ClassLoader */
 $loader = require __DIR__.'/app/autoload.php';
 
 $environment = getenv('SHOPWARE_ENV');


### PR DESCRIPTION
This PR should improve the workflow on the initial creation of a new project by reducing the number of necessary composer events and showing messages only after the creation is complete.

It can be testet with `composer create-project "shopware/composer-project:dev-change-install-event" my_project_name --no-interaction --stability=dev`

The installation cannot be dropped directly into `app/bin/install.sh` since that would require interactivity and one point of this repository is to allow for automatic deployments, for which no interactivity is a must have.