### PR TITLE
Revert 47 fix legacy plugin system links

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
     },
     "extra": {
         "installer-paths": {
-            "Plugins/Community/Backend/": ["type:shopware-backend-plugin"],
-            "Plugins/Community/Core/": ["type:shopware-core-plugin"],
-            "Plugins/Community/Frontend/": ["type:shopware-frontend-plugin"]
+            "Plugins/Local/Backend/{$name}/": ["type:shopware-backend-plugin"],
+            "Plugins/Local/Core/{$name}/": ["type:shopware-core-plugin"],
+            "Plugins/Local/Frontend/{$name}/": ["type:shopware-frontend-plugin"]
         }
     },
     "include-path": [

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
     },
     "extra": {
         "installer-paths": {
-            "Plugins/Local/Backend/{$name}/": ["type:shopware-backend-plugin"],
-            "Plugins/Local/Core/{$name}/": ["type:shopware-core-plugin"],
-            "Plugins/Local/Frontend/{$name}/": ["type:shopware-frontend-plugin"]
+            "Plugins/Community/Backend/{$name}/": ["type:shopware-backend-plugin"],
+            "Plugins/Community/Core/{$name}/": ["type:shopware-core-plugin"],
+            "Plugins/Community/Frontend/{$name}/": ["type:shopware-frontend-plugin"]
         }
     },
     "include-path": [


### PR DESCRIPTION
Without ${name} will composer replace the entire folder on each installation. So only one plugin can be installed in each Namespace.

This PR reverts that change 🙈 
https://github.com/FriendsOfShopware/packages/issues/30