### PR TITLE
Parse environment configuration with individual database parameters

### DIFF
--- a/app/config/config.php
+++ b/app/config/config.php
@@ -6,6 +6,12 @@ if (isset($_SERVER['DATABASE_URL']) && $db = parse_url($_SERVER['DATABASE_URL'])
     if (!isset($db['pass'])) {
         $db['pass'] = '';
     }
+} else if (isset($_ENV['DB_USERNAME']) && isset($_ENV['DB_PASSWORD']) && isset($_ENV['DB_DATABASE']) && isset($_ENV['DB_HOST']) && isset($_ENV['DB_PORT'])) {
+    $db['user'] = $_ENV['DB_USERNAME'];
+    $db['pass'] = $_ENV['DB_PASSWORD'];
+    $db['path'] = $_ENV['DB_DATABASE'];
+    $db['host'] = $_ENV['DB_HOST'];
+    $db['port'] = $_ENV['DB_PORT'];
 } else {
     die('Critical environment variable \'DATABASE_URL\' missing!' . PHP_EOL);
 }


### PR DESCRIPTION
The `.env` file created by `app/bin/install.sh` advetizes to use multiple parameters to define the database connection if the password contains special characters. These parameters should be used if `DATABASE_URL` is not set.

```
# If e.g. the password contains special chars not allowed in a URL, you can define each parameter by itself instead
DB_HOST="127.0.0.1"
DB_DATABASE="shopware"
DB_USERNAME="shopware"
DB_PASSWORD="$shopware"
DB_PORT="3306"
```