### PR TITLE
Downgrade PHP to `^7.3` in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         ]
     },
     "require": {
-        "php": "^7.4",
+        "php": "^7.3",
         "composer/installers": "^1.0",
         "shopware/shopware": "5.7.x-dev",
         "composer/package-versions-deprecated": "^1.8",


### PR DESCRIPTION
The PHP version was changed in commit 493bfa6e87d in order to "Make compatbile with Shopware 5.7" but Shopware 5.7 only
requires PHP 7.3 -- https://github.com/shopware/shopware/blob/62ce970e75436aa9a5446e80e106cc3d091dcc2a/composer.json#L19