### PR TITLE
Require Shopware 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^7.0",
         "composer/installers": "^1.0",
-        "shopware/shopware": "^5.5",
+        "shopware/shopware": "5.5.*",
         "ocramius/package-versions": "1.2.0",
         "vlucas/phpdotenv": "^3.1"
     },


### PR DESCRIPTION
Currently when creating a shopware project using
```console
composer create-project shopware/composer-project:5.5.x shopware55 --no-interaction --stability=dev
```
results in the most recent stable version of shopware being installed.

I expected the most recent 5.5 Shopware version actually. 
