### PR TITLE
Require Shopware 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^7.2",
         "composer/installers": "^1.0",
-        "shopware/shopware": "^5.6",
+        "shopware/shopware": "5.6.*",
         "composer/package-versions-deprecated": "^1.8",
         "vlucas/phpdotenv": "^3.1"
     },


### PR DESCRIPTION
When creating a shopware project using
```console
composer create-project shopware/composer-project:5.6.x shopware56 --no-interaction --stability=dev
```
this should always use a 5.6 Shopware version.