### PR TITLE
Allow empty ports in `DATABASE_URL`

### DIFF
--- a/app/config/config.php
+++ b/app/config/config.php
@@ -19,7 +19,7 @@ $composerConfig = [
         'password' => $db['pass'],
         'dbname'   => $db['path'],
         'host'     => $db['host'],
-        'port'     => $db['port'],
+        'port'     => $db['port'] ?? 3306,
     ],
 
     'template' => [

--- a/app/config/config.php
+++ b/app/config/config.php
@@ -19,7 +19,7 @@ $composerConfig = [
         'password' => $db['pass'],
         'dbname'   => $db['path'],
         'host'     => $db['host'],
-        'port'     => $db['port'] ?? 3306,
+        'port'     => $db['port'] ?? null,
     ],
 
     'template' => [


### PR DESCRIPTION
Currently, using a `DATABASE_URL` like `mysql://shopware:shopware@shopware-db/shopware` works, but throws a warning due to the missing `port`-part. This fixes this issue.